### PR TITLE
Overcoming jvm method body size limit 

### DIFF
--- a/masquerade-core/pom.xml
+++ b/masquerade-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.1.OPT</version>
+        <version>0.2.2.OPT</version>
     </parent>
 
     <artifactId>masquerade-core</artifactId>

--- a/masquerade-core/pom.xml
+++ b/masquerade-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.2.OPT</version>
+        <version>0.2.3</version>
     </parent>
 
     <artifactId>masquerade-core</artifactId>

--- a/masquerade-core/pom.xml
+++ b/masquerade-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1.OPT</version>
     </parent>
 
     <artifactId>masquerade-core</artifactId>

--- a/masquerade-core/src/main/java/com/flipkart/masquerade/Configuration.java
+++ b/masquerade-core/src/main/java/com/flipkart/masquerade/Configuration.java
@@ -50,4 +50,11 @@ public interface Configuration {
     default Fallback fallback() {
         return null;
     }
+    default int maxStatementsInMethod() {
+        return 1000;
+    }
+
+    default String methodPrefixForChainedMethods(){
+        return "chainedMethod";
+    }
 }

--- a/masquerade-core/src/main/java/com/flipkart/masquerade/processor/RepositoryProcessor.java
+++ b/masquerade-core/src/main/java/com/flipkart/masquerade/processor/RepositoryProcessor.java
@@ -73,7 +73,7 @@ public class RepositoryProcessor {
         final TypeSpec.Builder repositoryBuilder = TypeSpec.classBuilder(SET_CLASS);
         repositoryBuilder.addModifiers(Modifier.PUBLIC);
 
-        final ChainedCodeBlockBuilder initializer = new ChainedCodeBlockBuilder(repositoryBuilder);
+        final ChainedCodeBlockBuilder initializer = new ChainedCodeBlockBuilder(configuration.methodPrefixForChainedMethods(), configuration.maxStatementsInMethod(), repositoryBuilder);
 
         for (Rule rule : configuration.getRules()) {
             /* Creates a Map of Class name and Mask */

--- a/masquerade-core/src/main/java/com/flipkart/masquerade/processor/RepositoryProcessor.java
+++ b/masquerade-core/src/main/java/com/flipkart/masquerade/processor/RepositoryProcessor.java
@@ -56,6 +56,8 @@ public class RepositoryProcessor {
         cloakBuilder.addField(FieldSpec
                 .builder(className, SET_PARAMETER, Modifier.PRIVATE, Modifier.FINAL)
                 .initializer("new $T()", className).build());
+        cloakBuilder.addInitializerBlock(CodeBlock.builder()
+                .addStatement("$L.initVCMap()", SET_PARAMETER).build());
         cloakBuilder.addMethod(MethodSpec
                 .methodBuilder(getRepositoryGetter()).returns(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
@@ -90,7 +92,10 @@ public class RepositoryProcessor {
             }
         }
 
-        repositoryBuilder.addInitializerBlock(initializer.build());
+        repositoryBuilder.addMethod(MethodSpec
+                .methodBuilder("initVCMap").returns(TypeName.VOID)
+                .addModifiers(Modifier.PUBLIC)
+                .addCode(initializer.build()).build());
         return repositoryBuilder.build();
     }
 

--- a/masquerade-core/src/main/java/com/flipkart/masquerade/processor/SerializationOverrideProcessor.java
+++ b/masquerade-core/src/main/java/com/flipkart/masquerade/processor/SerializationOverrideProcessor.java
@@ -117,11 +117,9 @@ public class SerializationOverrideProcessor extends OverrideProcessor {
     @Override
     protected void handleFieldKeys(Class<?> clazz, FieldMeta field, MethodSpec.Builder methodBuilder) {
         resolveInclusionLevel(clazz, field);
-        if (field.getInclusionLevel() != JsonInclude.Include.ALWAYS) {
-            CodeBlock inclusionCondition = constructInclusionCondition(field);
-            if (field.isMaskable()) {
-                methodBuilder.beginControlFlow("$L", inclusionCondition);
-            }
+        CodeBlock inclusionCondition = constructInclusionCondition(field);
+        if (field.isMaskable()) {
+            methodBuilder.beginControlFlow("$L", inclusionCondition);
         }
         methodBuilder.addStatement("$L.append($S)", SERIALIZED_OBJECT, QUOTES + field.getSerializableName() + QUOTES + ":");
     }
@@ -129,7 +127,7 @@ public class SerializationOverrideProcessor extends OverrideProcessor {
     @Override
     protected void handleFieldValues(FieldMeta field, MethodSpec.Builder methodBuilder) {
         methodBuilder.addStatement("$L.append($S)", SERIALIZED_OBJECT, ",");
-        if (field.getInclusionLevel() != JsonInclude.Include.ALWAYS && field.isMaskable()) {
+        if (field.isMaskable()) {
             methodBuilder.endControlFlow();
         }
     }
@@ -257,8 +255,7 @@ public class SerializationOverrideProcessor extends OverrideProcessor {
                         return CodeBlock.of("if ($L.$L() != null && !$L.$L().isEmpty())", OBJECT_PARAMETER, getterName, OBJECT_PARAMETER, getterName);
                     }
                 default:
-                    fieldMeta.setMaskable(false);
-                    return null;
+                    return CodeBlock.of("if ($L.$L() != null || !$L.$L())", OBJECT_PARAMETER, getterName, EVAL_PARAMETER, "isDefaultNonNullInclusion");
             }
         }
     }

--- a/masquerade-core/src/main/java/com/flipkart/masquerade/serialization/ChainedCodeBlockBuilder.java
+++ b/masquerade-core/src/main/java/com/flipkart/masquerade/serialization/ChainedCodeBlockBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Flipkart Internet, pvt ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flipkart.masquerade.serialization;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.lang.model.element.Modifier;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * User: bageshwar.pn
+ * Date: 09/04/20
+ * Time: 3:12 PM
+ * This class splits the method body into 1000 statements per method.
+ *
+ * Helpful when the generated method's body could potentially be really huge, which would fail during compilation
+ * since JVM puts a hard limit of 64Kb for the method body.
+ */
+public class ChainedCodeBlockBuilder {
+
+    private static final int STATEMENT_LIMIT = 1000;
+    private static final String DEFAULT_METHOD_PREFIX = "chainedMethod";
+
+    private int nStatements;
+    private List<CodeBlock.Builder> initializers;
+    private CodeBlock.Builder currentInitializer;
+    private String methodPrefix;
+    private TypeSpec.Builder owningClass;
+
+    public ChainedCodeBlockBuilder(TypeSpec.Builder owningClass){
+        this(DEFAULT_METHOD_PREFIX, owningClass);
+    }
+
+    /**
+     *
+     * @param methodPrefix The prefix to be used to generate method names for the chained method.
+     * @param owningClass The class where the chained methods will be added.
+     */
+    public ChainedCodeBlockBuilder(String methodPrefix, TypeSpec.Builder owningClass){
+        this.methodPrefix = methodPrefix;
+        this.owningClass = owningClass;
+
+        this.currentInitializer = CodeBlock.builder();
+        this.initializers = new LinkedList<>();
+        this.initializers.add(currentInitializer);
+    }
+
+    public void addStatement(String format, Object... args) {
+
+        if(nStatements > STATEMENT_LIMIT){
+            nStatements = 0;
+            currentInitializer = CodeBlock.builder();
+            initializers.add(currentInitializer);
+        }
+
+        nStatements++;
+        currentInitializer.addStatement(format, args);
+    }
+
+    public CodeBlock build(){
+        if(initializers.size() == 1){
+            return currentInitializer.build();
+        } else {
+            // add n new methods and chain them together
+            int nMethod = 1;
+            CodeBlock.Builder chainedMethodInitializer =  CodeBlock.builder();
+            for(CodeBlock.Builder initializer : initializers){
+                String methodName = methodPrefix + (nMethod++);
+                owningClass.addMethod(MethodSpec
+                        .methodBuilder(methodName).returns(TypeName.VOID)
+                        .addModifiers(Modifier.PRIVATE)
+                        .addCode(initializer.build()).build());
+
+                chainedMethodInitializer.addStatement("$L()", methodName);
+            }
+
+            return chainedMethodInitializer.build();
+        }
+    }
+}

--- a/masquerade-core/src/main/java/com/flipkart/masquerade/serialization/ChainedCodeBlockBuilder.java
+++ b/masquerade-core/src/main/java/com/flipkart/masquerade/serialization/ChainedCodeBlockBuilder.java
@@ -35,27 +35,23 @@ import java.util.List;
  */
 public class ChainedCodeBlockBuilder {
 
-    private static final int STATEMENT_LIMIT = 1000;
-    private static final String DEFAULT_METHOD_PREFIX = "chainedMethod";
-
     private int nStatements;
     private List<CodeBlock.Builder> initializers;
     private CodeBlock.Builder currentInitializer;
     private String methodPrefix;
     private TypeSpec.Builder owningClass;
-
-    public ChainedCodeBlockBuilder(TypeSpec.Builder owningClass){
-        this(DEFAULT_METHOD_PREFIX, owningClass);
-    }
+    private int maxStatementsInMethod;
 
     /**
      *
      * @param methodPrefix The prefix to be used to generate method names for the chained method.
+     * @param maxStatementsInMethod The number of statements per chained method.
      * @param owningClass The class where the chained methods will be added.
      */
-    public ChainedCodeBlockBuilder(String methodPrefix, TypeSpec.Builder owningClass){
+    public ChainedCodeBlockBuilder(String methodPrefix, int maxStatementsInMethod, TypeSpec.Builder owningClass){
         this.methodPrefix = methodPrefix;
         this.owningClass = owningClass;
+        this.maxStatementsInMethod = maxStatementsInMethod;
 
         this.currentInitializer = CodeBlock.builder();
         this.initializers = new LinkedList<>();
@@ -64,7 +60,7 @@ public class ChainedCodeBlockBuilder {
 
     public void addStatement(String format, Object... args) {
 
-        if(nStatements > STATEMENT_LIMIT){
+        if(nStatements > maxStatementsInMethod){
             nStatements = 0;
             currentInitializer = CodeBlock.builder();
             initializers.add(currentInitializer);

--- a/masquerade-maven-plugin/pom.xml
+++ b/masquerade-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1.OPT</version>
     </parent>
 
     <artifactId>masquerade-maven-plugin</artifactId>

--- a/masquerade-maven-plugin/pom.xml
+++ b/masquerade-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.1.OPT</version>
+        <version>0.2.2.OPT</version>
     </parent>
 
     <artifactId>masquerade-maven-plugin</artifactId>

--- a/masquerade-maven-plugin/pom.xml
+++ b/masquerade-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.2.OPT</version>
+        <version>0.2.3</version>
     </parent>
 
     <artifactId>masquerade-maven-plugin</artifactId>

--- a/masquerade-sample/pom.xml
+++ b/masquerade-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.2.OPT</version>
+        <version>0.2.3</version>
     </parent>
 
     <artifactId>masquerade-sample</artifactId>
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>com.flipkart.rome</groupId>
                 <artifactId>masquerade-maven-plugin</artifactId>
-                <version>0.2.2.OPT</version>
+                <version>0.2.3</version>
                 <configuration>
                     <configurationClass>com.flipkart.masquerade.test.TestConfig</configurationClass>
                     <targetFile>${project.build.sourceDirectory}</targetFile>

--- a/masquerade-sample/pom.xml
+++ b/masquerade-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1.OPT</version>
     </parent>
 
     <artifactId>masquerade-sample</artifactId>
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>com.flipkart.rome</groupId>
                 <artifactId>masquerade-maven-plugin</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.1.OPT</version>
                 <configuration>
                     <configurationClass>com.flipkart.masquerade.test.TestConfig</configurationClass>
                     <targetFile>${project.build.sourceDirectory}</targetFile>

--- a/masquerade-sample/pom.xml
+++ b/masquerade-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.rome</groupId>
         <artifactId>masquerade</artifactId>
-        <version>0.2.1.OPT</version>
+        <version>0.2.2.OPT</version>
     </parent>
 
     <artifactId>masquerade-sample</artifactId>
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>com.flipkart.rome</groupId>
                 <artifactId>masquerade-maven-plugin</artifactId>
-                <version>0.2.1.OPT</version>
+                <version>0.2.2.OPT</version>
                 <configuration>
                     <configurationClass>com.flipkart.masquerade.test.TestConfig</configurationClass>
                     <targetFile>${project.build.sourceDirectory}</targetFile>

--- a/masquerade-sample/src/main/java/com/flipkart/masquerade/test/Eval.java
+++ b/masquerade-sample/src/main/java/com/flipkart/masquerade/test/Eval.java
@@ -23,6 +23,7 @@ public class Eval {
     public Platform platform;
     private int version;
     private String client;
+    private boolean defaultNonNullInclusion;
 
     public Eval() {
     }
@@ -46,5 +47,17 @@ public class Eval {
 
     public void setClient(String client) {
         this.client = client;
+    }
+
+    public boolean isDefaultNonNullInclusion() {
+        return defaultNonNullInclusion;
+    }
+
+    public boolean isNullKeySupported() {
+        return defaultNonNullInclusion;
+    }
+
+    public void setDefaultNonNullInclusion(boolean defaultNonNullInclusion) {
+        this.defaultNonNullInclusion = defaultNonNullInclusion;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -114,15 +114,10 @@
     </repositories>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>fk-art-snapshot</id>
-            <name>libs-snapshot</name>
-            <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-snapshots-local</url>
-        </snapshotRepository>
         <repository>
-            <id>fk-art-release</id>
-            <name>libs-rel</name>
-            <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-release-local</url>
+            <id>clojars</id>
+            <name>Clojars repository</name>
+            <url>https://clojars.org/repo</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.rome</groupId>
     <artifactId>masquerade</artifactId>
-    <version>0.2.1.OPT</version>
+    <version>0.2.2.OPT</version>
     <packaging>pom</packaging>
 
     <name>Masquerade</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.rome</groupId>
     <artifactId>masquerade</artifactId>
-    <version>0.2.2.OPT</version>
+    <version>0.2.3</version>
     <packaging>pom</packaging>
 
     <name>Masquerade</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.flipkart.rome</groupId>
     <artifactId>masquerade</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1.OPT</version>
     <packaging>pom</packaging>
 
     <name>Masquerade</name>
@@ -114,10 +114,15 @@
     </repositories>
 
     <distributionManagement>
+        <snapshotRepository>
+            <id>fk-art-snapshot</id>
+            <name>libs-snapshot</name>
+            <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-snapshots-local</url>
+        </snapshotRepository>
         <repository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
+            <id>fk-art-release</id>
+            <name>libs-rel</name>
+            <url>http://artifactory.fkinternal.com/artifactory/v1.0/artifacts/libs-release-local</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
JVM puts a 64kb limit on method body. This limit is hit in one of the generated methods for Version Control Map initialisation. 

This PR introduces a way to split such methods into multiple methods (each of 1000 statements)